### PR TITLE
Add mail composer (#12)

### DIFF
--- a/Hacktoberfest iOS/Controller/ContributorTableViewController.swift
+++ b/Hacktoberfest iOS/Controller/ContributorTableViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SafariServices
+import MessageUI
 
 class ContributorCell: UITableViewCell{
     @IBOutlet weak var nameLabel: UILabel!
@@ -60,13 +61,31 @@ class ContributorTableViewController: UITableViewController {
         let contributor = Datasource.contributors[index]
         for item in contributor.socialHandles {
             let action = UIAction(title: item.imageName, image: UIImage(named: item.imageName), identifier: nil, discoverabilityTitle: nil) { _ in
-                self.openWebsite(item.urlString)
+                if case .mail = item {
+                    self.openMailComposer(with: item.urlString)
+                } else {
+                    self.openWebsite(item.urlString)
+                }
             }
             actions.append(action)
         }
         let cancel = UIAction(title: "Cancel", attributes: .destructive) { _ in}
         actions.append(cancel)
         return UIMenu(title: "", children: actions)
+    }
+}
+
+extension ContributorTableViewController: MFMailComposeViewControllerDelegate {
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true)
+    }
+    
+    private func openMailComposer(with mail: String?) {
+        guard MFMailComposeViewController.canSendMail(), let mail = mail, !mail.isEmpty else { return }
+        let composeVC = MFMailComposeViewController()
+        composeVC.setToRecipients([mail])
+        composeVC.mailComposeDelegate = self
+        present(composeVC, animated: true)
     }
 }
 
@@ -78,9 +97,6 @@ extension UIViewController : SFSafariViewControllerDelegate{
                 self.present(safariVC, animated: true, completion: nil)
                 safariVC.delegate = self
             }
-
-            }
         }
-        
     }
-
+}


### PR DESCRIPTION
### Description
- Add mail composer when selecting `mail` option in contributors' context menu  
- Fix some curly brackets indentation

Fixes #12 

### Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
- Go to contributors tab
- Open context menu
- Tap `mail` option (make sure that the `mail` in datasource is not empty)
- The composer vc will show up
- Enter detail then tap send


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] My changes generate no new warnings 
