### PR TITLE
Replace FrameworkModel struct with enum

### DIFF
--- a/Hacktoberfest iOS/Controller/DetailViewController.swift
+++ b/Hacktoberfest iOS/Controller/DetailViewController.swift
@@ -9,13 +9,13 @@ import UIKit
 
 final class DetailViewController: UIViewController {
     
-    var framework: FrameworkModel = .unknowned
+    var framework: FrameworkModel?
     
     @IBOutlet weak var titleLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        titleLabel.text = framework.name
+        titleLabel.text = framework?.name
         //TODO initial setup
     }
     

--- a/Hacktoberfest iOS/Controller/DetailViewController.swift
+++ b/Hacktoberfest iOS/Controller/DetailViewController.swift
@@ -7,15 +7,15 @@
 
 import UIKit
 
-class DetailViewController: UIViewController {
+final class DetailViewController: UIViewController {
     
-    var framework = ""
+    var framework: FrameworkModel = .unknowned
     
     @IBOutlet weak var titleLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        titleLabel.text = framework
+        titleLabel.text = framework.name
         //TODO initial setup
     }
     

--- a/Hacktoberfest iOS/Controller/FrameworkTableViewController.swift
+++ b/Hacktoberfest iOS/Controller/FrameworkTableViewController.swift
@@ -17,7 +17,7 @@ final class FrameworkTableViewController: UITableViewController {
     
     var cellIdentifier = "frameworkCell"
     var segueIdentifier = "frameworkToDetail"
-    var framework: FrameworkModel = .unknowned
+    var framework: FrameworkModel?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Hacktoberfest iOS/Controller/FrameworkTableViewController.swift
+++ b/Hacktoberfest iOS/Controller/FrameworkTableViewController.swift
@@ -13,11 +13,11 @@ class FrameworkCell: UITableViewCell {
     @IBOutlet weak var subtitleLabel: UILabel!
 }
 
-class FrameworkTableViewController: UITableViewController {
+final class FrameworkTableViewController: UITableViewController {
     
     var cellIdentifier = "frameworkCell"
     var segueIdentifier = "frameworkToDetail"
-    var framework = "Framework"
+    var framework: FrameworkModel = .unknowned
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -55,7 +55,7 @@ class FrameworkTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        framework = Datasource.frameworks[indexPath.row].name
+        framework = Datasource.frameworks[indexPath.row]
         performSegue(withIdentifier: segueIdentifier, sender: self)
     }
     

--- a/Hacktoberfest iOS/Model/Datasource.swift
+++ b/Hacktoberfest iOS/Model/Datasource.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Datasource {
+enum Datasource {
     static let contributors : [ContributorModel] = [
         .init(name: "Aaryan Kothari", social: [.github(url: "https://github.com/aaryankotharii"),
                                                .LinkedIn(url: "https://linkedin.com/in/aaryankotharii"),
@@ -20,11 +20,5 @@ struct Datasource {
                                               .mail(url: "")])
     ]
     
-    static let frameworks: [FrameworkModel] = [
-        .init(name: "UIKit", description: "Provides view architecture for implementing interface."),
-        .init(name: "SafariServices", description: "Integrates Safari behaviors into app."),
-        .init(name: "MapKit", description: "Embeds maps directly app windows and views."),
-        .init(name: "SceneKit", description: "Combines 3D content using high-level scene descriptions."),
-        .init(name: "SwiftUI", description: "Builds UI with a declarative Swift syntax.")
-    ]
+    static let frameworks: [FrameworkModel] = FrameworkModel.allCases
 }

--- a/Hacktoberfest iOS/Model/FrameworkModel.swift
+++ b/Hacktoberfest iOS/Model/FrameworkModel.swift
@@ -7,16 +7,26 @@
 
 import Foundation
 
-enum FrameworkModel: String, CaseIterable {
-    case uiKit = "UIKit"
-    case safariServices = "SafariServices"
-    case mapKit = "MapKit"
-    case sceneKit = "SceneKit"
-    case swiftUI = "SwiftUI"
-    case unknowned = "Framework"
+enum FrameworkModel: CaseIterable {
+    case uiKit
+    case safariServices
+    case mapKit
+    case sceneKit
+    case swiftUI
     
     var name: String {
-        return self.rawValue
+        switch self {
+        case .uiKit:
+            return "UIKit"
+        case .safariServices:
+            return "SafariServices"
+        case .mapKit:
+            return "MapKit"
+        case .sceneKit:
+            return "SceneKit"
+        case .swiftUI:
+            return "SwiftUI"
+        }
     }
     
     var description: String {
@@ -31,8 +41,6 @@ enum FrameworkModel: String, CaseIterable {
             return "Combines 3D content using high-level scene descriptions."
         case .swiftUI:
             return "Builds UI with a declarative Swift syntax."
-        case .unknowned:
-            return "Framework not defined."
         }
     }
 }

--- a/Hacktoberfest iOS/Model/FrameworkModel.swift
+++ b/Hacktoberfest iOS/Model/FrameworkModel.swift
@@ -7,12 +7,32 @@
 
 import Foundation
 
-struct FrameworkModel {
-    let name: String
-    let description: String
+enum FrameworkModel: String, CaseIterable {
+    case uiKit = "UIKit"
+    case safariServices = "SafariServices"
+    case mapKit = "MapKit"
+    case sceneKit = "SceneKit"
+    case swiftUI = "SwiftUI"
+    case unknowned = "Framework"
     
-    init(name: String, description: String){
-        self.name = name
-        self.description = description
+    var name: String {
+        return self.rawValue
+    }
+    
+    var description: String {
+        switch self {
+        case .uiKit:
+            return "Provides view architecture for implementing interface."
+        case .safariServices:
+            return "Integrates Safari behaviors into app."
+        case .mapKit:
+            return "Embeds maps directly app windows and views."
+        case .sceneKit:
+            return "Combines 3D content using high-level scene descriptions."
+        case .swiftUI:
+            return "Builds UI with a declarative Swift syntax."
+        case .unknowned:
+            return "Framework not defined."
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR propose to replace the FrameworkModel struct with an enum, since we are using static names and descriptions.
This change will also help to handle the logic inside the DetailViewController, for switching between the examples to show, depending on the table view row selection.

Helper for [#7]

### Type of Change:

- Code

### How Has This Been Tested?
This is a code improvement that doesn’t change any functionality.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
